### PR TITLE
Patch heap overflow in Floating Point Parsing.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ruby1.8 (1:1.8.7.374-1bbox2~lucid1) lucid; urgency=high
+
+  * Fix for security bug CVE-2013-4164.
+
+ -- Graeme Mathieson <mathie@woss.name>  Fri, 22 Nov 2013 11:32:10 +0000
+
 ruby1.8 (1:1.8.7.374-1bbox1~lucid1) lucid; urgency=high
 
   * New upstream release, ruby 1.8.7-p374

--- a/debian/patches/131122_float_parsing_overflow.patch
+++ b/debian/patches/131122_float_parsing_overflow.patch
@@ -1,0 +1,68 @@
+diff --git a/test/ruby/test_float.rb b/test/ruby/test_float.rb
+index b6e643d..6daf061 100644
+--- a/test/ruby/test_float.rb
++++ b/test/ruby/test_float.rb
+@@ -171,4 +171,10 @@ class TestFloat < Test::Unit::TestCase
+     assert_raise(ArgumentError) { 1.0 < nil }
+     assert_raise(ArgumentError) { 1.0 <= nil }
+   end
++
++  def test_long_string
++    assert_separately([], <<-'end;')
++    assert_in_epsilon(10.0, ("1."+"1"*300000).to_f*9)
++    end;
++  end
+ end
+diff --git a/util.c b/util.c
+index 208db59..8a6f3cf 100644
+--- a/util.c
++++ b/util.c
+@@ -892,6 +892,11 @@ extern void *MALLOC(size_t);
+ #else
+ #define MALLOC malloc
+ #endif
++#ifdef FREE
++extern void FREE(void*);
++#else
++#define FREE free
++#endif
+ 
+ #ifndef Omit_Private_Memory
+ #ifndef PRIVATE_MEM
+@@ -1176,7 +1181,7 @@ Balloc(int k)
+ #endif
+ 
+     ACQUIRE_DTOA_LOCK(0);
+-    if ((rv = freelist[k]) != 0) {
++    if (k <= Kmax && (rv = freelist[k]) != 0) {
+         freelist[k] = rv->next;
+     }
+     else {
+@@ -1186,7 +1191,7 @@ Balloc(int k)
+ #else
+         len = (sizeof(Bigint) + (x-1)*sizeof(ULong) + sizeof(double) - 1)
+                 /sizeof(double);
+-        if (pmem_next - private_mem + len <= PRIVATE_mem) {
++        if (k <= Kmax && pmem_next - private_mem + len <= PRIVATE_mem) {
+             rv = (Bigint*)pmem_next;
+             pmem_next += len;
+         }
+@@ -1205,6 +1210,10 @@ static void
+ Bfree(Bigint *v)
+ {
+     if (v) {
++        if (v->k > Kmax) {
++            FREE(v);
++            return;
++        }
+         ACQUIRE_DTOA_LOCK(0);
+         v->next = freelist[v->k];
+         freelist[v->k] = v;
+@@ -2200,6 +2209,7 @@ break2:
+         for (; c >= '0' && c <= '9'; c = *++s) {
+ have_dig:
+             nz++;
++            if (nf > DBL_DIG * 2) continue;
+             if (c -= '0') {
+                 nf += nz;
+                 for (i = 1; i < nz; i++)


### PR DESCRIPTION
Provide a patch to 1.8.7 which fixes CVE-2013-4164.

It's been a long while since I've built Debian packages... :smile: 
